### PR TITLE
Make Docker image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 COPY . .
-RUN go build -o pinless
+RUN CGO_ENABLED=0 go build -o pinless
 
 FROM scratch
 COPY --from=build /app/pinless /usr/local/bin/pinless


### PR DESCRIPTION
Since Pinless is entirely statically linked, it can work just fine with a `scratch` (blank) base image. It trims off a couple of MB off the built image size and reduces attack surface.